### PR TITLE
chore: clarify dependencies section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ This project is still WIP, we are currently at an early stage where we are figur
 git clone --recurse-submodules git@github.com:Meta-A/bpm.git
 ```
 
+# Dependencies
+
+To build our project, you need to have the following dependencies installed:
+- `pkg-config`
+- `clang`
+- `protobuf`
+
+On Arch Linux, you can install them by running the following command:
+```bash
+pacman -S pkg-config clang protobuf
+```
+
 # Current properties & features
 * Rust language
 * Hashing of source code & binaries


### PR DESCRIPTION
This PR brings improvements to the README file:
- Added a new section to describe the dependencies needed to build the project.
- Added a specific command to install dependencies on Arch Linux.